### PR TITLE
Fixed error in metadata checks

### DIFF
--- a/local/test_event.json
+++ b/local/test_event.json
@@ -7,5 +7,5 @@
     "diff_url": "https://github.com/Codertocat/Hello-World/pull/2.diff",
     "patch_url": "https://github.com/Codertocat/Hello-World/pull/2.patch",
     "issue_url": "https://api.github.com/repos/Codertocat/Hello-World/issues/2",
-    "number": 65}
+    "number": 110}
 }

--- a/main.py
+++ b/main.py
@@ -139,7 +139,7 @@ FILEPATH_META = "forecasts/"
 is_meta_error, meta_err_output = check_for_metadata(filepath=FILEPATH_META)
 
 # list contains all changes in the data_processed folder
-data_processed_changes = forecasts + forecasts_err + metadatas + other_files
+data_processed_changes = forecasts + forecasts_err + metadatas
 if data_processed_changes:
     # check if metadata file is present in main repo
     if not metadatas:


### PR DESCRIPTION
In the previous version changes in non-forecast folders threw a metadata error.