### PR TITLE
add warning in case of negative forecasts

### DIFF
--- a/codebase/covid19.py
+++ b/codebase/covid19.py
@@ -62,6 +62,7 @@ def covid19_row_validator(column_index_dict, row, codes):
     """
     Does COVID19-specific row validation. Notes:
     - Checks in order:
+    0. value
     1. location
     2. quantiles
     3. forecast_date and target_end_date (terminates if invalid)
@@ -80,6 +81,11 @@ def covid19_row_validator(column_index_dict, row, codes):
     from .cdc_io import _parse_date  # avoid circular imports
 
     error_messages = []  # returned value. filled next
+    
+    # 0. Validate forecast value - Currently not enforced because truth can contain negative values
+    #value = row[column_index_dict['value']]
+    #if float(value) < 0:
+    #    error_messages.append(f"Error > negative value in forecast: {value!r}. row={row}")
 
     # 1. validate location (ISO-2 code)
     location = row[column_index_dict['location']]

--- a/codebase/validation_functions/non_negative_forecasts.py
+++ b/codebase/validation_functions/non_negative_forecasts.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Mar 26 15:18:25 2021
+
+@author: Jannik
+"""
+
+import pandas as pd
+
+def non_negative_values(file):
+    """
+    Parameters
+    ----------
+    file : path
+
+    Returns
+    -------
+    String containing a warning if file contains negative forecasts
+
+    """
+    
+    result = []
+    
+    df = pd.read_csv(file)
+    negative = df["value"]<0
+    
+    
+    if negative.any():
+        result.append(f"Warning > negative value in forecast")
+            
+    return result

--- a/local/test_event.json
+++ b/local/test_event.json
@@ -7,5 +7,5 @@
     "diff_url": "https://github.com/Codertocat/Hello-World/pull/2.diff",
     "patch_url": "https://github.com/Codertocat/Hello-World/pull/2.patch",
     "issue_url": "https://api.github.com/repos/Codertocat/Hello-World/issues/2",
-    "number": 141}
+    "number": 147}
 }


### PR DESCRIPTION
I decided to add a new function that checks if a file contains negative values. If this is the case the bot creates a "warning" comment. 

If you decide that forecasts with negatives values should fail the checks, uncommenting lines 85 to 88 (Step 0) in codebase/covid19.py will do the trick. In this case the added warning part in main.py should be deleted.