### PR TITLE
Fix warnings problem

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,7 +192,7 @@ if is_meta_error or len(errors)>0:
 
 forecasts_to_vis = False
 
-if len(warning) > 0:
+if len(warnings) > 0:
     warning_message = ""
     for file in warnings.keys():
         warning_message += str(file) + warning[file] + "\n\n"


### PR DESCRIPTION
Commit https://github.com/epiforecasts/covid19-forecast-hub-europe-validations/commit/5dc1410a57d1b3523a537988f08bcb14281c00a4 added warnings but this is causing validation errors: https://github.com/epiforecasts/covid19-forecast-hub-europe/pull/160/checks?check_run_id=2204795251

I think this should fix it.