### PR TITLE
fixed a bug that allowed teams to delete their metadata file

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request_target' or local:
 
 forecasts = [file for file in files_changed if pat.match(file.filename) is not None]
 forecasts_err = [file for file in files_changed if pat_other.match(file.filename) is not None]
-metadatas = [file for file in files_changed if pat_meta.match(file.filename) is not None]
+metadatas = [file for file in files_changed if pat_meta.match(file.filename) is not None and file.status != "removed"]
 other_files = [file for file in files_changed if (pat.match(file.filename) is None and pat_meta.match(file.filename) is None)]
 
 if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request_target':


### PR DESCRIPTION
As seen in this case https://github.com/epiforecasts/covid19-forecast-hub-europe/pull/276, the current checks miss deletions of metadata files.
The new solution will result in a "Missing metadata" error that fails the job.

Code was manually tested on the following PRs (number plus short description of the contents):
276 - job now fails as expected (Missing metadata error)
277 - no forecasts added
283 - bulk from germany
281 - changes forecast files/metadata file and other files
273 - regular rejected pr
248 - regular rejected pr
263 - regular accepted pr