### PR TITLE
Clean up dependency list

### DIFF
--- a/codebase/cdc_io.py
+++ b/codebase/cdc_io.py
@@ -1,10 +1,12 @@
+# Standard modules
 import csv
 import datetime
 from itertools import groupby
 
+# To list in requirements.txt
 import pymmwr
 
-#
+# Local modules
 # date formats
 #
 from .quantile_io import POINT_PREDICTION_CLASS, BIN_DISTRIBUTION_CLASS

--- a/codebase/covid19.py
+++ b/codebase/covid19.py
@@ -1,8 +1,13 @@
+# Standard modules
 import datetime
+from pathlib import Path
+
+# To list in requirements.txt
 import click
 import pandas as pd
-from pathlib import Path
 from pyprojroot import here
+
+# Local modules
 from .quantile_io import json_io_dict_from_quantile_csv_file
 
 #

--- a/codebase/quantile_io.py
+++ b/codebase/quantile_io.py
@@ -1,3 +1,4 @@
+# Standard modules
 import csv
 import math
 from collections import defaultdict

--- a/codebase/test_formatting.py
+++ b/codebase/test_formatting.py
@@ -1,18 +1,22 @@
-from .covid19 import validate_quantile_csv_file
+# Standard modules
 import glob
 from pprint import pprint
 import sys
 import os
+import collections
+from datetime import datetime
+from itertools import chain
+from pathlib import Path
+
+# To list in requirements.txt
 import pandas as pd
 import numpy as np
-from datetime import datetime
 import yaml
-from itertools import chain
-import collections
 from github import Github
-from pathlib import Path
 from pyprojroot import here
 
+# Local modules
+from .covid19 import validate_quantile_csv_file
 from .validation_functions.metadata import check_for_metadata, get_metadata_model, output_duplicate_models
 from .validation_functions.forecast_filename import validate_forecast_file_name
 from .validation_functions.forecast_date import filename_match_forecast_date

--- a/codebase/validation_functions/forecast_date.py
+++ b/codebase/validation_functions/forecast_date.py
@@ -1,6 +1,8 @@
-import pandas as pd
+# Standard modules
 import os
 
+# To list in requirements.txt
+import pandas as pd
 
 def filename_match_forecast_date(filepath):
     df = pd.read_csv(filepath)

--- a/codebase/validation_functions/forecast_filename.py
+++ b/codebase/validation_functions/forecast_filename.py
@@ -1,3 +1,4 @@
+# Standard modules
 import os
 
 

--- a/codebase/validation_functions/metadata.py
+++ b/codebase/validation_functions/metadata.py
@@ -8,7 +8,6 @@ import dateutil
 from dateutil.parser import parse
 import yaml
 import pandas as pd
-
 from pykwalify.core import Core
 
 SCHEMA_FILE = 'schema.yml'

--- a/codebase/validation_functions/metadata.py
+++ b/codebase/validation_functions/metadata.py
@@ -1,8 +1,11 @@
-import dateutil
+# Standard modules
 import os
 import glob
-from dateutil.parser import parse
 import re
+
+# To list in requirements.txt
+import dateutil
+from dateutil.parser import parse
 import yaml
 import pandas as pd
 

--- a/main.py
+++ b/main.py
@@ -5,16 +5,20 @@ Created on Sat Mar  6 19:04:35 2021
 @author: Jannik
 """
 
+# Standard modules
 import re
 import os
 import json
 import glob
-from github import Github
-import github
 import urllib.request
 import sys
 import shutil
 
+# To list in requirements.txt
+from github import Github
+import github
+
+# Local modules
 from codebase.test_formatting import forecast_check
 from codebase.test_formatting import forecast_check, validate_forecast_file, print_output_errors
 from codebase.validation_functions.metadata import check_for_metadata, get_metadata_model, output_duplicate_models

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,9 @@
-pymmwr
-pyyaml
-click
-pandas
-requests
-gitpython
-pygsheets
-unidecode
-epiweeks
-selenium
-webdriver_manager
-pyprojroot
-pygithub
-https://github.com/hannanabdul55/pykwalify/archive/master.zip
+click           # covid19.py
+numpy           # test_formatting.py
+pandas          # test_formatting.py, non_negative_forecasts.py, metadata.py, forecast_date.py
+pygithub        # main.py, test_formatting.py
+pymmwr          # cdc_io.py
+pyprojroot      # test_formatting.py
+python-dateutil # metadata.py
+pyyaml          # test_formatting.py, metadata.py
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click           # covid19.py
 numpy           # test_formatting.py
 pandas          # test_formatting.py, non_negative_forecasts.py, metadata.py, forecast_date.py
 pygithub        # main.py, test_formatting.py
+pykwalify       # metadata.py
 pymmwr          # cdc_io.py
 pyprojroot      # test_formatting.py
 python-dateutil # metadata.py


### PR DESCRIPTION
Fix https://github.com/epiforecasts/covid19-forecast-hub-europe/issues/51

I double checked each `import` instruction in each `.py` file. We end up removing quite a lot of dependencies (selenium, webdriver, gitpython, etc.) but looking at the DE/PL hub, these seem to be used in other actions (such as [`auto-download-lanl-covid19.py`](https://github.com/KITmetricslab/covid19-forecast-hub-de/blob/7983c315b2b3ad878f109fb74af8805f92291840/code/auto_download/auto-download-lanl-covid19.py)) but not in the validation.

New addition are numpy (but I suspect it was unnoticed because it's so common it was already installed for most people) and python-dateutil.