### PR TITLE
Use hub config for shared variables

### DIFF
--- a/codebase/project_variables.py
+++ b/codebase/project_variables.py
@@ -8,14 +8,20 @@ Collection of global variables used as inputs to validation functions
 """
 import pandas as pd
 from pyprojroot import here
+import yaml
+import urllib.request
+
+# Get hub config
+config = urllib.request.urlopen('https://raw.githubusercontent.com/epiforecasts/covid19-forecast-hub-europe/main/forecasthub.yml')
+project_config = yaml.load(config.read(), Loader=yaml.FullLoader)
 
 ## covid19.py
-CODES = list(pd.read_csv(here('./data-locations/locations_eu.csv'))['location'])
-VALID_TARGET_NAMES = [f"{_} wk ahead inc death" for _ in range(1, 20)] + \
-                     [f"{_} wk ahead inc case" for _ in range(1, 20)]
-VALID_QUANTILES = [0.010, 0.025, 0.050, 0.100, 0.150, 0.200, 0.250, 0.300,
-                   0.350, 0.400, 0.450, 0.500, 0.550, 0.600, 0.650, 0.700,
-                   0.750, 0.800, 0.850, 0.900, 0.950, 0.975, 0.990]
+FORECAST_WEEK_DAY = project_config['forecast_week_day']
+CODES = list(pd.read_csv(here('./data-locations/locations_eu.csv'))['location']) # add to config
+VALID_TARGET_NAMES = [f"{_} wk ahead {target_variable}" \
+                      for _ in range(1, 20) \
+                      for target_variable in project_config['target_variables']]
+VALID_QUANTILES = project_config['forecast_type']['quantiles']
 
 ## quantile_io.py 
 BIN_DISTRIBUTION_CLASS = 'bin'

--- a/codebase/validation_functions/forecast_date.py
+++ b/codebase/validation_functions/forecast_date.py
@@ -1,3 +1,10 @@
+"""
+Checks that: 
+- there is only one forecast_date in the forecast_date column
+- the date in the filename matches the date in the forecast_date col
+Compatible with any forecast date
+"""
+
 # Standard modules
 import os
 

--- a/codebase/validation_functions/forecast_filename.py
+++ b/codebase/validation_functions/forecast_filename.py
@@ -1,3 +1,8 @@
+"""
+Checks that:
+    - filepath (without date) matches the intended forecast folder
+"""
+
 # Standard modules
 import os
 


### PR DESCRIPTION
Updates `project_variables.py` to read in from the new hub config file. 

There are still a few things which could be added to the hub config and read in here - e.g. locations and perhaps others - but this is a start.

- Should address #17 
- Should close #20 - depending on [this PR](https://github.com/epiforecasts/covid19-forecast-hub-europe/pull/672) in main repo to add `inc hosp` to targets in config

(Also added a bit of extra commenting on some completely unrelated scripts - just saw and wanted to update them as I was going along. No changes to code there)