### PR TITLE
Validate any day submission

### DIFF
--- a/codebase/covid19.py
+++ b/codebase/covid19.py
@@ -138,9 +138,8 @@ def covid19_row_validator(column_index_dict, row, codes):
     # 5.2 Forecast date should always be Mon -- no longer checked
 
     # 5.3 Set expected target end date from forecast date
-    # - Set which weekdays are can start within the forecast epiweek
-    #   i.e. Sunday and Monday
-    #   TODO: use our config file to get this and translate into epi-weekdays
+    # - Set which weekdays forecasts are allowed to start within the forecast epiweek
+    #   i.e. between Sunday (day 1) and latest day we allow submission for a week (Monday) 
     overlap_days = 1, 2
     # - Get weekday of forecast date
     forecast_weekday = weekday_to_sun_based[forecast_date.weekday()]


### PR DESCRIPTION
Aims to fix #19. Updates validation of the `target_end_date` to account for a `forecast_date` on any day of the week.

1. The `forecast_date` is assigned to the relevant forecasting Saturday - since Saturday is the end of the epiweek before starting the first full forecast epiweek. 
   - The relevant Saturday assigned for a given `forecast_date` is based on its (epi)weekday:
     -  `forecast_date` of Sundays or Mondays: the preceding Saturday (since we accept submission on Sunday/Monday even though they overlap with the first forecast week)
     -  `forecast_date` of any other day: the following Saturday

2. Then the expected `target_end_date` is set by working forward in weeks to the `n wk ahead` Saturday. E.g:
   - a `forecast_date` of 11 or 12 July with a target `1 wk ahead` expects `target_end_date` of 17 July
   - a `forecast_date` of 13, 14, 15, 16, 17 July with a target `1 wk ahead` expects `target_end_date` of 24 July

3. Then the expected is compared with given target end date.

I've tested with mocked up files with a range of correct and incorrect `forecast_date` / `target_end_date` combinations, and all works for me, but glad for any independent checks!

Should also be very easy to update here if we accept `forecast_date`s up to Tuesday.

PS. The base for this branch is `use-hub-config` #21 but it doesn't make any real difference to this PR compared to basing off main.