### PR TITLE
Fix schema.yml by providing content of sequence

### DIFF
--- a/codebase/validation_functions/metadata.py
+++ b/codebase/validation_functions/metadata.py
@@ -2,6 +2,7 @@
 import os
 import glob
 import re
+import click
 
 # To list in requirements.txt
 import dateutil
@@ -27,7 +28,7 @@ def validate_metadata_contents(metadata, filepath, cache):
 
     pat_model = re.compile(r"(.+)\.yml")
     model_name_file = re.findall(pat_model, os.path.basename(filepath))[0]
-    # print(f"model_name_file: {model_name_file} \t\t filepath: {filepath}")
+    click.echo(f"* validating metadata_file '{model_name_file}.yml'...")
 
     # This is a critical error and hence do not run further checks.
     if 'model_abbr' not in metadata:

--- a/codebase/validation_functions/metadata.py
+++ b/codebase/validation_functions/metadata.py
@@ -25,7 +25,7 @@ def validate_metadata_contents(metadata, filepath, cache):
         metadata_error_output.extend(['METADATA_ERROR: %s' % err for err in core.validation_errors])
         is_metadata_error = True
 
-    pat_model = re.compile(r"metadata-(.+)\.yml")
+    pat_model = re.compile(r"(.+)\.yml")
     model_name_file = re.findall(pat_model, os.path.basename(filepath))[0]
     # print(f"model_name_file: {model_name_file} \t\t filepath: {filepath}")
 

--- a/schema.yml
+++ b/schema.yml
@@ -22,7 +22,7 @@ mapping:
           - type: map
             mapping:
                 'name':
-                    require: True
+                    required: True
                     type: str
                 'affiliation':
                     type: str

--- a/schema.yml
+++ b/schema.yml
@@ -18,6 +18,20 @@ mapping:
     'model_contributors':
         required: True
         type: seq
+        sequence: 
+          - type: map
+            mapping:
+                'name':
+                    require: True
+                    type: str
+                'affiliation':
+                    type: str
+                'email':
+                    type: str
+                'orcid':
+                    type: str
+                'twitter':
+                    type: str                    
     'website_url':
         required: True
         type: str


### PR DESCRIPTION
This may solve https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/actions/runs/4356541557/jobs/7614687721.

As I understand it, pykwalify is complaining that the schema is invalid because it says `model_contributors` is of `type: seq` without ever saying what is in this `sequence`.

I didn't test this PR on an actual example so please don't merge without any test :grimacing: 